### PR TITLE
Remove discontinued params: first-bill recur-bill

### DIFF
--- a/src/SclNominetEpp/Request/Update/Domain.php
+++ b/src/SclNominetEpp/Request/Update/Domain.php
@@ -116,8 +116,6 @@ class Domain extends Request
         $extension = $extensionXML->addChild('domain-nom-ext:update', '', $extensionNS);
         $extension->addAttribute('schemaLocation', $extensionXSI, 'xsi');
 
-        $extension->addChild('first-bill');
-        $extension->addChild('recur-bill');
         $extension->addChild('auto-bill');
         $extension->addChild('next-bill');
         $extension->addChild('notes');


### PR DESCRIPTION
It is no longer possible to set domain names for direct registrant billing (first bill and recur bill); these fields were discontinued from June 2015.